### PR TITLE
Upgrade/azure sql server

### DIFF
--- a/azure/sql-server/README.md
+++ b/azure/sql-server/README.md
@@ -227,7 +227,7 @@ module "mssql" {
 
     - (string) **`secondary_server_id`** _[since v1.0.0]_
 
-        Defines the ID of the MS SQL server to failover to. This server must exists in a different region.
+        Defines the ID of the MS SQL server to failover to. This server **must** exist in a different region.
 
     - (map(string)) **`additional_tags = {}`** _[since v1.0.0]_
 

--- a/azure/sql-server/README.md
+++ b/azure/sql-server/README.md
@@ -6,12 +6,17 @@ This module will create and configure an Azure SQL Server and databases.
 
 ## Table of Contents
 
+- [Requirements](#requirements)
 - [Example Usage](#example-usage)
     - [Basic Usage](#basic-usage)
 - [Argument Reference](#argument-reference)
     - [Mandatory](#mandatory)
     - [Optional](#optional)
 - [Outputs](#outputs)
+
+## Requirements
+
+- Terraform v1.3.0+
 
 ## Example Usage
 

--- a/azure/sql-server/README.md
+++ b/azure/sql-server/README.md
@@ -214,7 +214,7 @@ module "mssql" {
 
 - (map(object)) **`failover_groups = {}`** _[since v1.0.0]_
 
-    Manages failover groups for databases failover
+    Manages failover groups for databases failover. In `{failover_group_name = {configurations}}` format. The failover group name must be globally unique.
 
     - (list(string)) **`databases`** _[since v1.0.0]_
 
@@ -234,7 +234,7 @@ module "mssql" {
 
     - (number) **`read_write_grace_period_minutes = 60`** _[since v1.0.0]_
 
-        The grace period in minutes, before failover with data loss is attempted for the read-write endpoint. Required when mode is `"Automatic"`
+        The grace period in minutes, before failover with data loss is attempted for the read-write endpoint. Required when `read_write_failover_policy = "Automatic"`
 
 - (object) **`firewall = null`** _[since v0.0.1]_
 

--- a/azure/sql-server/_terraform.tf
+++ b/azure/sql-server/_terraform.tf
@@ -1,3 +1,0 @@
-terraform {
-  experiments = [module_variable_optional_attrs]
-}

--- a/azure/sql-server/mssql-database.tf
+++ b/azure/sql-server/mssql-database.tf
@@ -47,12 +47,8 @@ locals {
 
       tags           = db_value.additional_tags
       ledger_enabled = db_value.ledger_enabled
-
-      license_type = db_value.bring_your_own_license != null ? (
-        db_value.bring_your_own_license ? "LicenseIncluded" : "BasePrice"
-      ) : "BasePrice"
-
-      max_size_gb = db_value.data_max_size
+      license_type   = db_value.bring_your_own_license ? "LicenseIncluded" : "BasePrice"
+      max_size_gb    = db_value.data_max_size
 
       recover_database_id = db_value.create_mode != null ? (
         contains(local.create_mode_table["Recovery"], db_value.create_mode) ? db_value.source_database_id : null
@@ -73,8 +69,9 @@ locals {
   vcore_models = {
     for db_name, db_value in var.databases :
     db_name => {
-      collation   = db_value.collation
-      create_mode = db_value.create_mode
+      auto_pause_delay_in_minutes = db_value.vcore_model.auto_pause_delay_in_minutes
+      collation                   = db_value.collation
+      create_mode                 = db_value.create_mode
 
       creation_source_database_id = db_value.create_mode != null ? (
         contains(local.create_mode_table["Create"], db_value.create_mode) ? db_value.source_database_id : null
@@ -82,12 +79,9 @@ locals {
 
       tags           = db_value.additional_tags
       ledger_enabled = db_value.ledger_enabled
-
-      license_type = db_value.bring_your_own_license != null ? (
-        db_value.bring_your_own_license ? "LicenseIncluded" : "BasePrice"
-      ) : "BasePrice"
-
-      max_size_gb = db_value.data_max_size
+      license_type   = db_value.bring_your_own_license ? "LicenseIncluded" : "BasePrice"
+      max_size_gb    = db_value.data_max_size
+      min_capacity   = db_value.vcore_model.tier == "Serverless" ? db_value.vcore_model.min_vcores : null
 
       recover_database_id = db_value.create_mode != null ? (
         contains(local.create_mode_table["Recovery"], db_value.create_mode) ? db_value.source_database_id : null
@@ -100,7 +94,7 @@ locals {
       restore_point_in_time = db_value.restore_point_in_time
 
       # For example: GP_S_Gen5_1
-      sku_name             = "${local.vcore_tier_table[db_value.vcore_model.tier]}${db_value.vcore_model.tier == "Serverless" ? "_S" : ""}_${db_value.vcore_model.compute != null ? db_value.vcore_model.compute : "Gen5"}_${db_value.vcore_model.vcores}"
+      sku_name             = "${local.vcore_tier_table[db_value.vcore_model.tier]}${db_value.vcore_model.tier == "Serverless" ? "_S" : ""}_${db_value.vcore_model.compute}_${db_value.vcore_model.vcores}"
       storage_account_type = db_value.backup_storage_redundancy
       read_scale           = db_value.read_scale_out_enabled
       zone_redundant       = db_value.zone_redundant

--- a/azure/sql-server/mssql-failover-groups.tf
+++ b/azure/sql-server/mssql-failover-groups.tf
@@ -1,0 +1,40 @@
+data "azurerm_mssql_database" "databases" {
+  depends_on = [
+    azurerm_mssql_database.dtu_models,
+    azurerm_mssql_database.vcore_models
+  ]
+
+  for_each = var.databases
+
+  name      = each.key
+  server_id = azurerm_mssql_server.mssql_server.id
+}
+
+resource "azurerm_mssql_failover_group" "failover_groups" {
+  depends_on = [
+    azurerm_mssql_database.dtu_models,
+    azurerm_mssql_database.vcore_models
+  ]
+
+  for_each = var.failover_groups
+
+  name      = each.key
+  server_id = azurerm_mssql_server.mssql_server.id
+
+  partner_server {
+    id = each.value.secondary_server_id
+  }
+
+  databases = [for db in each.value.databases : data.azurerm_mssql_database.databases[db].id]
+
+  read_write_endpoint_failover_policy {
+    mode          = each.value.read_write_failover_policy
+    grace_minutes = each.value.read_write_grace_period_minutes
+  }
+
+  tags = merge(
+    local.common_tags,
+    var.additional_tags_all,
+    each.value.additional_tags
+  )
+}

--- a/azure/sql-server/mssql-firewall-rules.tf
+++ b/azure/sql-server/mssql-firewall-rules.tf
@@ -9,9 +9,7 @@ resource "azurerm_mssql_firewall_rule" "firewall_rules" {
 
 resource "azurerm_mssql_firewall_rule" "allow_access_to_azure_services" {
   count = var.firewall != null ? (
-    var.firewall.allow_access_to_azure_services != null ? (
-      var.firewall.allow_access_to_azure_services ? 1 : 0
-    ) : 0
+    var.firewall.allow_access_to_azure_services ? 1 : 0
   ) : 0
 
   name             = "Allow Access To Azure Services"

--- a/azure/sql-server/variables.tf
+++ b/azure/sql-server/variables.tf
@@ -1,7 +1,7 @@
 variable "azure" {
   type = object({
     resource_group_name = string
-    location            = optional(string)
+    location            = optional(string, null)
   })
 
   description = "Where the resources will be deployed on"
@@ -27,7 +27,7 @@ variable "additional_tags_all" {
 variable "azure_ad_authentication" {
   type = object({
     object_id = string
-    tenant_id = optional(string)
+    tenant_id = optional(string, null)
   })
 
   description = "Defines an Azure AD identity as administrator for this SQL server, can be used with SQL Authentication"
@@ -42,31 +42,31 @@ variable "connection_policy" {
 
 variable "databases" {
   type = map(object({
-    additional_tags           = optional(map(string))
-    backup_storage_redundancy = optional(string)
-    bring_your_own_license    = optional(bool)
-    collation                 = optional(string)
-    create_mode               = optional(string)
-    data_max_size             = optional(number) # 2 GB
+    additional_tags           = optional(map(string), {})
+    backup_storage_redundancy = optional(string, "Geo")
+    bring_your_own_license    = optional(bool, false)
+    collation                 = optional(string, "SQL_Latin1_General_CP1_CI_AS")
+    create_mode               = optional(string, "Default")
+    data_max_size             = optional(number, 2)
 
     dtu_model = optional(object({
-      tier = string           # Basic, Standard, Premium
-      dtu  = optional(number) # Standard = 10, Premium = 125
+      tier = string # Basic, Standard, Premium
+      dtu  = optional(number, null)
     }))
 
     vcore_model = optional(object({
       tier                        = string # GeneralPurpose, Hyperscale, Serverless
       vcores                      = number
-      auto_pause_delay_in_minutes = optional(number)
-      compute                     = optional(string) # Gen5
-      min_vcores                  = optional(number) # 1
+      auto_pause_delay_in_minutes = optional(number, -1)
+      compute                     = optional(string, "Gen5")
+      min_vcores                  = optional(number, 1)
     }))
 
-    ledger_enabled         = optional(bool)
-    read_scale_out_enabled = optional(bool) # true
-    restore_point_in_time  = optional(string)
-    source_database_id     = optional(string)
-    zone_redundant         = optional(bool) # false
+    ledger_enabled         = optional(bool, false)
+    read_scale_out_enabled = optional(bool, true)
+    restore_point_in_time  = optional(string, null)
+    source_database_id     = optional(string, null)
+    zone_redundant         = optional(bool, false)
   }))
 
   description = "Defines multiple databases"
@@ -76,7 +76,7 @@ variable "databases" {
 variable "firewall" {
   type = object({
     rules                          = map(string)
-    allow_access_to_azure_services = optional(bool)
+    allow_access_to_azure_services = optional(bool, false)
   })
 
   description = "Defines firewall rules for the SQL server"

--- a/azure/sql-server/variables.tf
+++ b/azure/sql-server/variables.tf
@@ -63,13 +63,26 @@ variable "databases" {
     }))
 
     ledger_enabled         = optional(bool, false)
-    read_scale_out_enabled = optional(bool, true)
+    read_scale_out_enabled = optional(bool, null)
     restore_point_in_time  = optional(string, null)
     source_database_id     = optional(string, null)
     zone_redundant         = optional(bool, false)
   }))
 
   description = "Defines multiple databases"
+  default     = {}
+}
+
+variable "failover_groups" {
+  type = map(object({
+    databases                       = list(string)
+    secondary_server_id             = string
+    additional_tags                 = optional(map(string), {})
+    read_write_failover_policy      = optional(string, "Automatic")
+    read_write_grace_period_minutes = optional(number, 60)
+  }))
+
+  description = "Defines SQL server failover groups"
   default     = {}
 }
 


### PR DESCRIPTION
- Updated code to remove the experimental feature since the optional object variable is [now GA](https://developer.hashicorp.com/terraform/language/upgrade-guides#concluding-the-optional-attributes-experiment). This is a breaking feature and is required for the newer version of Terraform (1.3 >)
- Added the ability to define failover groups
- Updated the README file to reflect new changes